### PR TITLE
SRCH-597 depend on activesupport >= 4, < 7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,14 @@ jobs:
   build:
     environment:
       RUBY_VERSION: << parameters.ruby_version >>
+      ACTIVESUPPORT_VERSION: << parameters.activesupport_version >>
     executor: test_executor
     parameters:
       ruby_version:
         type: string
+      activesupport_version:
+        type: string
+        default: '~> 5.0'
     steps:
       - checkout
 
@@ -57,5 +61,15 @@ workflows:
           name: 'ruby 2.5.5'
           ruby_version: 2.5.5
       - build:
-          name: 'ruby 2.6.3'
+          name: 'ruby 2.6.3, activesupport 4'
           ruby_version: 2.6.3
+          activesupport_version: '4.0.0'
+      - build:
+          name: 'ruby 2.6.3, activesupport 5'
+          ruby_version: 2.6.3
+          activesupport_version: '~> 5.0'
+      - build:
+          name: 'ruby 2.6.3, activesupport 6'
+          ruby_version: 2.6.3
+          activesupport_version: '6.0.0.rc1'
+

--- a/sitemaps.gemspec
+++ b/sitemaps.gemspec
@@ -28,5 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "byebug", "~> 8.2"
   spec.add_development_dependency "yard", "~> 0.9.11"
 
-  spec.add_runtime_dependency 'activesupport', (ENV['ACTIVESUPPORT_VERSION'] || '>= 4, < 7')
+  spec.add_runtime_dependency 'activesupport',
+    (ENV['ACTIVESUPPORT_VERSION'] || ['>= 4', '< 7'])
 end

--- a/sitemaps.gemspec
+++ b/sitemaps.gemspec
@@ -4,29 +4,29 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'sitemaps/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "sitemaps_parser"
+  spec.name          = 'sitemaps_parser'
   spec.version       = Sitemaps::VERSION
-  spec.authors       = ["Jonathan Raphaelson"]
-  spec.email         = ["jraphaelson@termscout.com"]
+  spec.authors       = ['Jonathan Raphaelson']
+  spec.email         = ['jraphaelson@termscout.com']
 
-  spec.summary       = "Retrieve and parse sitemaps, according to the sitemaps.org spec."
-  spec.homepage      = "http://github.com/GSA/sitemaps"
-  spec.license       = "CC0 1.0 Universal"
+  spec.summary       = 'Retrieve and parse sitemaps, according to the sitemaps.org spec.'
+  spec.homepage      = 'http://github.com/GSA/sitemaps'
+  spec.license       = 'CC0 1.0 Universal'
 
   files = `git ls-files -z`.split("\x0")
   files.reject! { |f| f.match(%r{^(test|spec|features)/}) }
 
   spec.files         = files
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_development_dependency "bundler", "~> 1"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "webmock", "~> 3.0"
-  spec.add_development_dependency "vcr", "~> 3"
-  spec.add_development_dependency "rubocop", "~> 0.71.0"
-  spec.add_development_dependency "byebug", "~> 8.2"
-  spec.add_development_dependency "yard", "~> 0.9.11"
+  spec.add_development_dependency 'bundler', '~> 1'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'webmock', '~> 3.0'
+  spec.add_development_dependency 'vcr', '~> 3'
+  spec.add_development_dependency 'rubocop', '~> 0.71.0'
+  spec.add_development_dependency 'byebug', '~> 8.2'
+  spec.add_development_dependency 'yard', '~> 0.9.11'
 
   spec.add_runtime_dependency 'activesupport',
     (ENV['ACTIVESUPPORT_VERSION'] || ['>= 4', '< 7'])

--- a/sitemaps.gemspec
+++ b/sitemaps.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "byebug", "~> 8.2"
   spec.add_development_dependency "yard", "~> 0.9.11"
 
-  spec.add_runtime_dependency "activesupport", "~> 4"
+  spec.add_runtime_dependency 'activesupport', (ENV['ACTIVESUPPORT_VERSION'] || '>= 4, < 7')
 end


### PR DESCRIPTION
This PR:
- allows this gem to be used with activesupport 4, 5, and 6
- tests the gem using activesupport 4, 5, and 6