### PR TITLE
SRCH-680 parse sitemaps including extra whitespace

### DIFF
--- a/lib/sitemaps/parser.rb
+++ b/lib/sitemaps/parser.rb
@@ -40,29 +40,33 @@ module Sitemaps
     # @api private
     # @private
     def self.parse_loc(root)
-      loc = root.get_text("loc").try(:value)
+      loc = get_text(root, 'loc')
       loc && URI.parse(loc) rescue nil
     end
 
     # @api private
     # @private
     def self.parse_lastmod(root)
-      mod = root.get_text("lastmod").try(:value)
+      mod = get_text(root, 'lastmod')
       mod && Time.parse(mod) rescue nil
     end
 
     # @api private
     # @private
     def self.parse_changefreq(root)
-      freq = root.get_text("changefreq").try(:value)
+      freq = get_text(root, 'changefreq')
       freq && VALID_CHANGEFREQ.include?(freq) ? freq.to_sym : nil
     end
 
     # @api private
     # @private
     def self.parse_priority(root)
-      priority = root.get_text("priority").try(:value) || "0.5"
+      priority = get_text(root, 'priority') || '0.5'
       priority && Float(priority) rescue 0.5 # default priority according to spec
+    end
+
+    def self.get_text(root, key)
+      root.get_text(key)&.value&.strip
     end
   end
 end

--- a/spec/fixtures/sitemap_with_whitespace.xml
+++ b/spec/fixtures/sitemap_with_whitespace.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+   <url>
+     <loc>
+       http://www.example.com/whitespace
+     </loc>
+     <lastmod>
+       2005-01-01
+     </lastmod>
+     <changefreq>
+       monthly
+     </changefreq>
+     <priority>
+       0.8
+     </priority>
+   </url>
+</urlset>

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -8,14 +8,16 @@ describe Sitemaps::Parser do
     REXML::Document.new(str).root
   end
 
+  let(:raw_sitemap) { sitemap_file('sitemap.valid.xml') }
+
   it "handles a max_entries parameter" do
-    result = Sitemaps::Parser.parse(sitemap_file, max_entries: 1)
+    result = Sitemaps::Parser.parse(raw_sitemap, max_entries: 1)
     expect(result.entries.length).to eq(1)
   end
 
   it "handles a filter block parameter" do
     filter = -> (entry) { entry.changefreq == :monthly }
-    result = Sitemaps::Parser.parse(sitemap_file, filter: filter)
+    result = Sitemaps::Parser.parse(raw_sitemap, filter: filter)
 
     expect(result.entries.length).to eq(1)
     expect(result.entries.first.changefreq).to eq(:monthly)
@@ -23,7 +25,7 @@ describe Sitemaps::Parser do
 
   it "handles both a max_entries and filter block parameter" do
     filter = -> (entry) { entry.priority > 0.4 } # matches default, total of 4 in the file
-    result = Sitemaps::Parser.parse(sitemap_file, max_entries: 2, filter: filter)
+    result = Sitemaps::Parser.parse(raw_sitemap, max_entries: 2, filter: filter)
 
     expect(result.entries.length).to eq(2)
     expect(result.entries.all?(&filter)).to be true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,36 +15,8 @@ end
 
 # helpers for accessing local file fixtures
 module SitemapFixtures
-  def sitemap_file
-    @sitemap_file ||= begin
-      path = File.join(File.dirname(__FILE__), "./fixtures/sitemap.valid.xml")
-      File.read(path).freeze
-    end
-  end
-
-  def sitemap_fixture
-    @sitemap_fixture ||= Sitemaps.parse(sitemap_file)
-  end
-
-  def invalid_file
-    @invalid_file ||= begin
-      path = File.join(File.dirname(__FILE__), "./fixtures/sitemap.invalid.xml")
-      File.read(path).freeze
-    end
-  end
-
-  def invalid_fixture
-    @invalid_fixture ||= Sitemaps.parse(invalid_file)
-  end
-
-  def sitemap_index_file
-    @sitemap_file ||= begin
-      path = File.join(File.dirname(__FILE__), "./fixtures/sitemap_index.valid.xml")
-      File.read(path).freeze
-    end
-  end
-
-  def sitemap_index_fixture
-    @sitemap_index_fixture ||= Sitemaps.parse(sitemap_index_file)
+  def sitemap_file(filename)
+    path = File.join(File.dirname(__FILE__), "./fixtures/#{filename}")
+    File.read(path).freeze
   end
 end


### PR DESCRIPTION
This PR:
- fixes parsing for sitemaps that include extra whitespace around the elements
- refactors some of the parsing specs & helpers
- resolves https://github.com/lygaret/sitemaps/issues/8