### PR TITLE
SRCH-699 require 100% code coverage

### DIFF
--- a/sitemaps.gemspec
+++ b/sitemaps.gemspec
@@ -4,29 +4,30 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'sitemaps/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "sitemaps_parser"
+  spec.name          = 'sitemaps_parser'
   spec.version       = Sitemaps::VERSION
-  spec.authors       = ["Jonathan Raphaelson"]
-  spec.email         = ["jraphaelson@termscout.com"]
+  spec.authors       = ['Jonathan Raphaelson']
+  spec.email         = ['jraphaelson@termscout.com']
 
-  spec.summary       = "Retrieve and parse sitemaps, according to the sitemaps.org spec."
-  spec.homepage      = "http://github.com/GSA/sitemaps"
-  spec.license       = "CC0 1.0 Universal"
+  spec.summary       = 'Retrieve and parse sitemaps, according to the sitemaps.org spec.'
+  spec.homepage      = 'http://github.com/GSA/sitemaps'
+  spec.license       = 'CC0 1.0 Universal'
 
   files = `git ls-files -z`.split("\x0")
   files.reject! { |f| f.match(%r{^(test|spec|features)/}) }
 
   spec.files         = files
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_development_dependency "bundler", "~> 1"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "webmock", "~> 3.0"
-  spec.add_development_dependency "vcr", "~> 3"
-  spec.add_development_dependency "rubocop", "~> 0.71.0"
-  spec.add_development_dependency "byebug", "~> 8.2"
-  spec.add_development_dependency "yard", "~> 0.9.11"
+  spec.add_development_dependency 'bundler', '~> 1'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'webmock', '~> 3.0'
+  spec.add_development_dependency 'vcr', '~> 3'
+  spec.add_development_dependency 'rubocop', '~> 0.71.0'
+  spec.add_development_dependency 'byebug', '~> 8.2'
+  spec.add_development_dependency 'yard', '~> 0.9.11'
+  spec.add_development_dependency 'simplecov', '~> 0.16'
 
-  spec.add_runtime_dependency "activesupport", "~> 4"
+  spec.add_runtime_dependency 'activesupport', '~> 4'
 end

--- a/spec/fetcher_spec.rb
+++ b/spec/fetcher_spec.rb
@@ -1,6 +1,25 @@
 require 'spec_helper'
 
 describe Sitemaps::Fetcher, vcr: { record: :new_episodes } do
+  subject(:fetch) { Sitemaps::Fetcher.fetch(uri) }
+
+  let(:uri) { URI('http://www.example.com') }
+
+  context 'when the request is successful' do
+    before do
+      stub_request(:get, 'http://www.example.com').
+        to_return(status: 200, body: 'response body')
+    end
+
+    it 'returns the response body' do
+      expect(fetch).to eq 'response body'
+    end
+
+    it 'can take a string as an argument' do
+      expect(Sitemaps::Fetcher.fetch('www.example.com')).to eq 'response body'
+    end
+  end
+
   it "can download a file" do
     uri    = URI.parse("http://httpbin.org/")
     source = Sitemaps::Fetcher.fetch(uri)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,17 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
-require 'sitemaps'
 require 'webmock/rspec'
 require 'vcr'
+require 'byebug'
+require 'simplecov'
+
+SimpleCov.minimum_coverage 100
+SimpleCov.start do
+  add_filter '/spec/'
+end
+
+# Must be required after SimpleCov is started
+require 'sitemaps'
 
 VCR.configure do |c|
   c.cassette_library_dir = File.join(File.dirname(__FILE__), './fixtures/vcr')


### PR DESCRIPTION
This PR:
- ensures that CI builds will fail if coverage drops below 100%
- adds specs for methods that were missing coverage